### PR TITLE
(Fix): Revert Python version to work with elastalert

### DIFF
--- a/elastalert/Dockerfile
+++ b/elastalert/Dockerfile
@@ -1,9 +1,9 @@
-FROM python:3.6.2-alpine3.6
+FROM python:2.7.14-alpine3.6
 
 MAINTAINER Micah Hausler, <micah@skuid.com>
 
 LABEL "OS_version"="alpine:3.6"
-LABEL "Python_version"="2.7.13" 
+LABEL "Python_version"="2.7.14" 
 
 RUN apk -U add \
     g++ \


### PR DESCRIPTION
Elastalert doesn’t like python version 3.x