### PR TITLE
PLIN-4287: add template processing for nginx

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -14,4 +14,5 @@ EXPOSE 443
 
 STOPSIGNAL SIGTERM
 
-CMD ["nginx", "-g", "daemon off;"]
+COPY start.sh /bin/start.sh
+ENTRYPOINT ["/bin/start.sh"]

--- a/nginx/start.sh
+++ b/nginx/start.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+if ! command -v envsubst &> /dev/null
+then
+	echo "This script requires envsubst from package gettext."
+	exit 1
+fi
+
+# get a comma-separated list of environment variables that are replaceable
+ENVVARS=$(awk 'BEGIN{for(v in ENVIRON) print "$" v}' |paste -sd "," -)
+
+# input directory
+INDIR=$1
+if [ -z $INDIR ]
+then
+	INDIR=/tmp/templates
+fi
+if [ ! -d $INDIR ]
+then
+	mkdir $INDIR
+fi
+
+# if there are template files, process them
+if [ -e $INDIR/*.template ]
+then
+	OUTDIR=$2
+	if [ -z $OUTDIR ]
+	then
+		OUTDIR=/tmp
+	fi
+	if [ ! -d $OUTDIR ]
+	then
+		mkdir $OUTDIR
+	fi
+
+	# loop over template files
+	for i in $INDIR/*.template
+	do
+		NEWNAME=$(basename $i ".template")	
+		DEST="$OUTDIR/$NEWNAME"
+
+		# read the first line of the template
+		read -r DEST_COMMENT<$i
+		# if we have a comment in the first line that starts with #dest, then the rest is the output path
+		if [[ $DEST_COMMENT == \#dest* ]] 
+		then
+		  DEST=${DEST_COMMENT:6}
+		fi
+
+		# substitute everything appearing in $ENVVARS in the template
+		cat $i | envsubst "$ENVVARS" > $DEST
+	done
+fi
+
+exec nginx -g "daemon off;"


### PR DESCRIPTION
https://inflight.atlassian.net/browse/PLIN-4827

This one is fun... essentially, this adds an entrypoint script to the docker container which will check a directory (defaults to /tmp/templates) for *.template files and process them with envsubst.

The idea is that we will mount our directory of template files into /tmp/templates, and the `#dest <path>` option on the first line will allow, e.g. nginx.conf.template output to /etc/openresty/nginx.conf and seaquill.conf.template to /etc/nginx/sites-enables/seaquill.conf.

I'm not sure how to test it until we get this built and I can use it with the templated nginx files in seaquill, but I tried it locally and it seems to work with a simple template.